### PR TITLE
Update AgentDetector library version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "matomo/device-detector": "^4.3"
+        "matomo/device-detector": "^6.1"
     },
     "require-dev": {
     },


### PR DESCRIPTION
The AgentDetector library version used in the package is `^4.3`, which is quite old. Bumped it to `^6.1`.